### PR TITLE
fix: migrate SMHI to snow1g endpoint and handle empty Photon queries

### DIFF
--- a/src/components/LocationModal/index.tsx
+++ b/src/components/LocationModal/index.tsx
@@ -43,7 +43,10 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
   const debouncedSearch = useDebounce(search, 500);
 
   // SWR network request for location search
-  const { data: locations } = useSWR(`${apiBasePhoton}${debouncedSearch}&limit=6`, searchFetcher);
+  const { data: locations } = useSWR(
+    debouncedSearch ? `${apiBasePhoton}${encodeURIComponent(debouncedSearch)}&limit=6` : null,
+    searchFetcher,
+  );
 
   useEffect(() => {
     if (search.length > 0) {

--- a/src/types/smhi.ts
+++ b/src/types/smhi.ts
@@ -3,7 +3,7 @@ import i18n from "i18n";
 import { WeatherIconEnum } from "~/enums/WeatherIcon";
 
 export interface WeatherData {
-  approvedTime: Date;
+  createdTime: Date;
   referenceTime: Date;
   geometry: Geometry;
   timeSeries: TimeSery[];
@@ -11,59 +11,27 @@ export interface WeatherData {
 
 export interface Geometry {
   type: string;
-  coordinates: Array<number[]>;
+  coordinates: number[];
 }
 
 export interface TimeSery {
-  validTime: Date;
-  parameters: Parameter[];
+  time: Date;
+  data: TimeData;
 }
 
-export interface Parameter {
-  name: Name;
-  levelType: LevelType;
-  level: number;
-  unit: Unit;
-  values: number[];
-}
-
-export enum LevelType {
-  Hl = "hl",
-  Hmsl = "hmsl",
-}
-
-export enum Name {
-  Gust = "gust",
-  HccMean = "hcc_mean",
-  LccMean = "lcc_mean",
-  MccMean = "mcc_mean",
-  Msl = "msl",
-  Pcat = "pcat",
-  Pmax = "pmax",
-  Pmean = "pmean",
-  Pmedian = "pmedian",
-  Pmin = "pmin",
-  R = "r",
-  Spp = "spp",
-  T = "t",
-  TccMean = "tcc_mean",
-  Tstm = "tstm",
-  Vis = "vis",
-  Wd = "wd",
-  Ws = "ws",
-  Wsymb2 = "Wsymb2",
-}
-
-export enum Unit {
-  Category = "category",
-  Cel = "Cel",
-  Degree = "degree",
-  HPa = "hPa",
-  KM = "km",
-  KgM2H = "kg/m2/h",
-  MS = "m/s",
-  Octas = "octas",
-  Percent = "percent",
+export interface TimeData {
+  air_temperature?: number;
+  wind_from_direction?: number;
+  wind_speed?: number;
+  wind_speed_of_gust?: number;
+  relative_humidity?: number;
+  air_pressure_at_mean_sea_level?: number;
+  visibility_in_air?: number;
+  cloud_area_fraction?: number;
+  precipitation_amount_min?: number;
+  precipitation_amount_max?: number;
+  precipitation_amount_mean?: number;
+  symbol_code?: number;
 }
 
 export const TextList = [

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -52,7 +52,7 @@ export async function rainFetcher(input: RequestInfo, init?: RequestInit): Promi
 }
 
 export const apiBaseSMHI =
-  "https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2/geotype/point/";
+  "https://opendata-download-metfcst.smhi.se/api/category/snow1g/version/1/geotype/point/";
 export const apiBaseYR = "https://api.met.no/weatherapi/locationforecast/2.0/complete?";
 export const apiBaseBigDataCloud = "https://api.bigdatacloud.net/data/reverse-geocode-client?";
 export const apiBasePhoton = "https://photon.komoot.io/api/?q=";

--- a/src/utils/smhi.ts
+++ b/src/utils/smhi.ts
@@ -45,21 +45,21 @@ function parseDays(
 
   // Iterate each day
   for (const time1 of times) {
-    if (isSameDay(new Date(time1.validTime), new Date(iterationDate))) continue;
+    if (isSameDay(new Date(time1.time), new Date(iterationDate))) continue;
 
     const iterationDay = {} as WeatherTypesUni.Day;
     iterationDay.hours = [];
-    iterationDate = time1.validTime;
+    iterationDate = time1.time;
 
     // Set sunrise and sunset
-    iterationDay.date = time1.validTime;
+    iterationDay.date = time1.time;
     const sunTimes = SunCalc.getTimes(new Date(iterationDay.date), lat, lon);
     iterationDay.sunrise = sunTimes.sunrise;
     iterationDay.sunset = sunTimes.sunset;
 
     // Iterate each hour
     for (const time2 of times) {
-      if (isSameDay(new Date(time2.validTime), new Date(iterationDate))) {
+      if (isSameDay(new Date(time2.time), new Date(iterationDate))) {
         iterationDay.hours.push(parseHour(time2, iterationDay.sunrise, iterationDay.sunset));
       }
     }
@@ -80,58 +80,33 @@ function parseHour(
   sunset: Date,
 ): WeatherTypesUni.Hour {
   const hour = {} as WeatherTypesUni.Hour;
-  hour.date = time.validTime;
-  time.parameters.forEach(param => {
-    switch (param.name) {
-      case WeatherTypesSMHI.Name.T:
-        hour.tempr = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Pmax:
-        hour.precMax = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Pmin:
-        hour.precMin = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Pmean:
-        hour.precMean = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Ws:
-        hour.wind = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Wd:
-        hour.windDir = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Msl:
-        hour.pressure = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Vis:
-        hour.vis = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.R:
-        hour.humidity = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Gust:
-        hour.gusts = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.TccMean:
-        hour.cloud = param.values[0];
-        break;
-      case WeatherTypesSMHI.Name.Wsymb2: {
-        const wsymb2Num = param.values[0];
-        const correctedForIndex = wsymb2Num - 1;
-        hour.text = WeatherTypesSMHI.TextList[correctedForIndex];
-        if (
-          new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-          new Date(hour.date).getHours() <= new Date(sunset).getHours()
-        ) {
-          hour.icon = WeatherTypesSMHI.IconListDay[correctedForIndex];
-        } else {
-          hour.icon = WeatherTypesSMHI.IconListNight[correctedForIndex];
-        }
-        break;
-      }
+  const data = time.data;
+  hour.date = time.time;
+  hour.tempr = data.air_temperature ?? 0;
+  hour.precMax = data.precipitation_amount_max ?? 0;
+  hour.precMin = data.precipitation_amount_min ?? 0;
+  hour.precMean = data.precipitation_amount_mean ?? 0;
+  hour.wind = data.wind_speed ?? 0;
+  hour.windDir = data.wind_from_direction ?? 0;
+  hour.pressure = data.air_pressure_at_mean_sea_level ?? 0;
+  hour.vis = data.visibility_in_air ?? 0;
+  hour.humidity = data.relative_humidity ?? 0;
+  hour.gusts = data.wind_speed_of_gust ?? 0;
+  hour.cloud = data.cloud_area_fraction ?? 0;
+
+  if (data.symbol_code !== undefined) {
+    const correctedForIndex = data.symbol_code - 1;
+    hour.text = WeatherTypesSMHI.TextList[correctedForIndex];
+    if (
+      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
+      new Date(hour.date).getHours() <= new Date(sunset).getHours()
+    ) {
+      hour.icon = WeatherTypesSMHI.IconListDay[correctedForIndex];
+    } else {
+      hour.icon = WeatherTypesSMHI.IconListNight[correctedForIndex];
     }
-  });
+  }
+
   hour.feelslike = calcFeelsLike(hour.tempr, hour.humidity, hour.wind);
   return hour;
 }


### PR DESCRIPTION
## Summary
- SMHI deprecated `pmp3g/version/2` (the host now 404s for the old paths). Migrated `apiBaseSMHI` to `snow1g/version/1` and adapted the parser/types to its flat schema: `validTime` → `time`, `parameters[].name/values` → `data.{key}` with renamed fields (`t` → `air_temperature`, `Wsymb2` → `symbol_code`, etc.). Wsymb2 1–27 numbering is unchanged so the existing icon/text lists still apply.
- Photon (komoot) now returns 400 on empty `q=`. Skip the search request until the user has typed something, and URL-encode the query.

## Test plan
- [ ] Pick SMHI in Settings → weather data loads for the current location.
- [ ] Open the location modal with no input → no failed request to photon.komoot.io.
- [ ] Type a query → Photon results appear; selecting one switches the location.
- [ ] Switch back to YR → still works as before.