### PR TITLE
fix: migrate SMHI parser to new API schema

### DIFF
--- a/src/components/GraphSwitcher/partials/GraphRain.tsx
+++ b/src/components/GraphSwitcher/partials/GraphRain.tsx
@@ -18,16 +18,12 @@ function GraphRain({ chartHours }: GraphProps) {
   // Makes sure that "edges" are smooth (otherwise null gets a cutoff)
   useEffect(() => {
     if (chartHours) {
-      for (let i = 0; i < chartHours.length; i++) {
-        if (
-          chartHours[i].precMax === 0 &&
-          !chartHours[i - 1]?.precMax &&
-          !chartHours[i + 1]?.precMax
-        ) {
-          chartHours[i].precMax = null;
-        }
-      }
-      setHoursData(chartHours);
+      const next = chartHours.map((hour, i) =>
+        hour.precMax === 0 && !chartHours[i - 1]?.precMax && !chartHours[i + 1]?.precMax
+          ? { ...hour, precMax: null }
+          : hour,
+      );
+      setHoursData(next);
     }
   }, [chartHours]);
 


### PR DESCRIPTION
## Summary
- Switch SMHI endpoint from `pmp3g/v2` to `snow1g/v1` and update the parser/types to the new response shape (`time` + `data` map of named fields, replacing `validTime` + `parameters[]` array).
- Replace mutating loop in `GraphRain` precipitation smoothing with a non-mutating `map`, so React state isn't updated in place.
- Guard `LocationModal` SWR fetch on a non-empty query and `encodeURIComponent` the search term.

## Test plan
- [ ] Load app with a Swedish location and confirm SMHI-sourced hours render (temp, wind, precip, icon).
- [ ] Open the rain graph and verify zero-precip edges still render smoothly.
- [ ] Open the location modal, type a query with spaces/special chars, and confirm results load without bad requests; clearing input issues no request.