### PR TITLE
fix: render forecast times in each location's local timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-router-dom": "^7.14.2",
     "recharts": "^3.8.1",
     "suncalc": "^1.9.0",
-    "swr": "^2.4.1"
+    "swr": "^2.4.1",
+    "tz-lookup": "^6.1.25"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       swr:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.5)
+      tz-lookup:
+        specifier: ^6.1.25
+        version: 6.1.25
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -3159,6 +3162,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  tz-lookup@6.1.25:
+    resolution: {integrity: sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -6633,6 +6639,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  tz-lookup@6.1.25: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/components/LocationModal/index.tsx
+++ b/src/components/LocationModal/index.tsx
@@ -24,9 +24,7 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
   const { t } = useTranslation();
 
   const { setLocation, setSelectedLocation, location } = useLocation();
-  const [savedLocations, setSavedLocations] = useState<Location[]>(
-    JSON.parse(getItem("locations") || "[]"),
-  );
+  const [savedLocations, setSavedLocations] = useState<Location[]>(loadSavedLocations);
   const [currentLocationSelected, setCurrentLocationSelected] = useState(
     getItem("selected-location") ? false : true,
   );
@@ -50,6 +48,12 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
   );
 
   useEffect(() => {
+    const upgraded = loadSavedLocations();
+    setSavedLocations(upgraded);
+    setItem("locations", JSON.stringify(upgraded));
+  }, []);
+
+  useEffect(() => {
     if (search.length > 0) {
       setIsSearching(true);
     } else {
@@ -71,10 +75,13 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
   // Add chosen location to saved locations
   function addLocation(location: Location) {
     const ensured = ensureTimezone(location);
-    const savedLocations = JSON.parse(getItem("locations") || "[]");
-    const newLocations: Location[] = savedLocations.find((l: Location) => l.name === ensured.name)
-      ? [...savedLocations]
-      : [...savedLocations, ensured];
+    if (!ensured) return;
+    const savedLocations = loadSavedLocations();
+    const existingIndex = savedLocations.findIndex(l => l.name === ensured.name);
+    const newLocations: Location[] =
+      existingIndex >= 0
+        ? savedLocations.map((l, i) => (i === existingIndex ? ensured : l))
+        : [...savedLocations, ensured];
     setItem("locations", JSON.stringify(newLocations));
     setItem("selected-location", JSON.stringify(ensured));
     setLocation(ensured);
@@ -83,14 +90,29 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
     closeModal();
   }
 
-  function ensureTimezone(location: Location): Location {
-    if (location.timezone && validateTimezone(location.timezone)) return location;
-    return { ...location, timezone: getTimezoneForCoords(location.lat, location.lon) };
+  function ensureTimezone(location: Partial<Location>): Location | undefined {
+    if (location.lat == null || location.lon == null || !location.name) return undefined;
+    const timezone =
+      location.timezone && validateTimezone(location.timezone)
+        ? location.timezone
+        : getTimezoneForCoords(location.lat, location.lon);
+    return {
+      lat: location.lat,
+      lon: location.lon,
+      name: location.name,
+      timezone,
+    };
+  }
+
+  function loadSavedLocations(): Location[] {
+    return (JSON.parse(getItem("locations") || "[]") as Partial<Location>[])
+      .map(ensureTimezone)
+      .filter((location): location is Location => Boolean(location));
   }
 
   // Remove chosen location from saved locations
   function removeLocation(location: Location) {
-    const savedLocations = JSON.parse(getItem("locations") || "[]");
+    const savedLocations = loadSavedLocations();
     const newLocations = savedLocations.filter((l: Location) => l.name !== location.name);
     setItem("locations", JSON.stringify(newLocations));
     const selectedLocation = JSON.parse(getItem("selected-location") || "null");

--- a/src/components/LocationModal/index.tsx
+++ b/src/components/LocationModal/index.tsx
@@ -10,6 +10,7 @@ import useDebounce from "~/hooks/useDebounce";
 import Location from "~/types/location";
 import { apiBasePhoton, searchFetcher } from "~/utils/constants";
 import { deleteItem, getItem, setItem } from "~/utils/storage";
+import { getTimezoneForCoords, validateTimezone } from "~/utils/timezone";
 
 import SearchBar from "../SearchBar";
 import styles from "./LocationModal.module.css";
@@ -69,16 +70,22 @@ export default function LocationModal({ isOpen, setOpen }: LocationModalProps) {
 
   // Add chosen location to saved locations
   function addLocation(location: Location) {
+    const ensured = ensureTimezone(location);
     const savedLocations = JSON.parse(getItem("locations") || "[]");
-    const newLocations: Location[] = savedLocations.find((l: Location) => l.name === location.name)
+    const newLocations: Location[] = savedLocations.find((l: Location) => l.name === ensured.name)
       ? [...savedLocations]
-      : [...savedLocations, location];
+      : [...savedLocations, ensured];
     setItem("locations", JSON.stringify(newLocations));
-    setItem("selected-location", JSON.stringify(location));
-    setLocation(location);
+    setItem("selected-location", JSON.stringify(ensured));
+    setLocation(ensured);
     setSavedLocations(newLocations);
     setCurrentLocationSelected(false);
     closeModal();
+  }
+
+  function ensureTimezone(location: Location): Location {
+    if (location.timezone && validateTimezone(location.timezone)) return location;
+    return { ...location, timezone: getTimezoneForCoords(location.lat, location.lon) };
   }
 
   // Remove chosen location from saved locations

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -5,6 +5,7 @@ import i18n from "~/i18n";
 import Location from "~/types/location";
 import { apiBaseBigDataCloud, locationFetcher } from "~/utils/constants";
 import { clearAllData, getItem, setItem } from "~/utils/storage";
+import { getTimezoneForCoords, validateTimezone } from "~/utils/timezone";
 
 type LocationContextType = {
   location?: Location;
@@ -23,6 +24,7 @@ const PreSelectLocation: Location = {
   lat: 59.3293,
   lon: 18.0686,
   name: "Stockholm",
+  timezone: "Europe/Stockholm",
 };
 
 interface APIData {
@@ -43,8 +45,12 @@ export function LocationContextProvider({ children }: LocationContextProps) {
     {
       onSuccess: (data: string | undefined) => {
         if (data && apiData) {
-          
-          setLocation({ lat: apiData.lat, lon: apiData.lon, name: data });
+          setLocation({
+            lat: apiData.lat,
+            lon: apiData.lon,
+            name: data,
+            timezone: getTimezoneForCoords(apiData.lat, apiData.lon),
+          });
         }
       },
     },
@@ -71,8 +77,12 @@ export function LocationContextProvider({ children }: LocationContextProps) {
 
   useEffect(() => {
     if (apiData && city) {
-      
-      setLocation({ lat: apiData.lat, lon: apiData.lon, name: city });
+      setLocation({
+        lat: apiData.lat,
+        lon: apiData.lon,
+        name: city,
+        timezone: getTimezoneForCoords(apiData.lat, apiData.lon),
+      });
     }
   }, [apiData]);
 
@@ -80,11 +90,28 @@ export function LocationContextProvider({ children }: LocationContextProps) {
     setLocation(undefined);
     const selectedLocation = getItem("selected-location");
     if (selectedLocation) {
-      const selectedLocationParsed = JSON.parse(selectedLocation) as Location;
-      setLocation(selectedLocationParsed);
+      const parsed = JSON.parse(selectedLocation) as Partial<Location>;
+      const upgraded = upgradeLocation(parsed);
+      if (upgraded) {
+        if (upgraded.timezone !== parsed.timezone) {
+          setItem("selected-location", JSON.stringify(upgraded));
+        }
+        setLocation(upgraded);
+      } else {
+        checkLocationPermission();
+      }
     } else {
       checkLocationPermission();
     }
+  }
+
+  function upgradeLocation(parsed: Partial<Location>): Location | undefined {
+    if (parsed.lat == null || parsed.lon == null || !parsed.name) return undefined;
+    const tz =
+      parsed.timezone && validateTimezone(parsed.timezone)
+        ? parsed.timezone
+        : getTimezoneForCoords(parsed.lat, parsed.lon);
+    return { lat: parsed.lat, lon: parsed.lon, name: parsed.name, timezone: tz };
   }
 
   function checkLocationPermission() {

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -31,6 +31,7 @@ interface APIData {
   lat: number;
   lon: number;
   userLang: string;
+  timezone: string;
 }
 
 export function LocationContextProvider({ children }: LocationContextProps) {
@@ -49,7 +50,7 @@ export function LocationContextProvider({ children }: LocationContextProps) {
             lat: apiData.lat,
             lon: apiData.lon,
             name: data,
-            timezone: getTimezoneForCoords(apiData.lat, apiData.lon),
+            timezone: apiData.timezone,
           });
         }
       },
@@ -81,7 +82,7 @@ export function LocationContextProvider({ children }: LocationContextProps) {
         lat: apiData.lat,
         lon: apiData.lon,
         name: city,
-        timezone: getTimezoneForCoords(apiData.lat, apiData.lon),
+        timezone: apiData.timezone,
       });
     }
   }, [apiData]);
@@ -130,10 +131,17 @@ export function LocationContextProvider({ children }: LocationContextProps) {
   }
 
   function getPositionSuccessCallback(pos: GeolocationPosition) {
-    const lon = pos.coords.longitude.toFixed(2);
-    const lat = pos.coords.latitude.toFixed(2);
+    const rawLon = pos.coords.longitude;
+    const rawLat = pos.coords.latitude;
+    const lon = rawLon.toFixed(2);
+    const lat = rawLat.toFixed(2);
 
-    setApiData({ lat: Number(lat), lon: Number(lon), userLang: i18n.language });
+    setApiData({
+      lat: Number(lat),
+      lon: Number(lon),
+      userLang: i18n.language,
+      timezone: getTimezoneForCoords(rawLat, rawLon),
+    });
   }
 
   useEffect(() => {

--- a/src/pages/HomePage/partials/Map/index.tsx
+++ b/src/pages/HomePage/partials/Map/index.tsx
@@ -133,6 +133,7 @@ export function Map() {
                 getHourString(
                   (getItem("unit-time") as timeUnits) || timeUnits.twentyfour,
                   new Date(frames[currentFrame.step].time * 1000),
+                  location.timezone,
                 )}
             </p>
           </div>

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -2,4 +2,5 @@ export default interface Location {
   name: string;
   lon: number;
   lat: number;
+  timezone: string;
 }

--- a/src/types/rawWeather.ts
+++ b/src/types/rawWeather.ts
@@ -12,6 +12,7 @@ export interface RawWeather {
   days: Day[];
   units: Units;
   city: string;
+  timezone: string;
 }
 export interface Units {
   temprUnit: temprUnits;

--- a/src/types/tz-lookup.d.ts
+++ b/src/types/tz-lookup.d.ts
@@ -1,0 +1,3 @@
+declare module "tz-lookup" {
+  export default function tzlookup(lat: number, lon: number): string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,15 +9,21 @@ import Weather from "~/types/weather";
 
 import formatWeather from "./formatWeather";
 import { parseWeather } from "./parseWeather";
+import { getTimezoneForCoords } from "./timezone";
 
 export async function searchFetcher(input: RequestInfo, init?: RequestInit): Promise<Location[]> {
   const res = await fetch(input, init);
   const data = (await res.json()) as LocationData;
-  return data.features.map(location => ({
-    name: location.properties.name,
-    lon: Math.round(location.geometry.coordinates[0] * 100 + Number.EPSILON) / 100,
-    lat: Math.round(location.geometry.coordinates[1] * 100 + Number.EPSILON) / 100,
-  }));
+  return data.features.map(location => {
+    const lon = Math.round(location.geometry.coordinates[0] * 100 + Number.EPSILON) / 100;
+    const lat = Math.round(location.geometry.coordinates[1] * 100 + Number.EPSILON) / 100;
+    return {
+      name: location.properties.name,
+      lon,
+      lat,
+      timezone: getTimezoneForCoords(lat, lon),
+    };
+  });
 }
 
 export async function locationFetcher(input: RequestInfo, init?: RequestInit): Promise<string> {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,13 +15,15 @@ export async function searchFetcher(input: RequestInfo, init?: RequestInit): Pro
   const res = await fetch(input, init);
   const data = (await res.json()) as LocationData;
   return data.features.map(location => {
-    const lon = Math.round(location.geometry.coordinates[0] * 100 + Number.EPSILON) / 100;
-    const lat = Math.round(location.geometry.coordinates[1] * 100 + Number.EPSILON) / 100;
+    const rawLon = location.geometry.coordinates[0];
+    const rawLat = location.geometry.coordinates[1];
+    const lon = Math.round(rawLon * 100 + Number.EPSILON) / 100;
+    const lat = Math.round(rawLat * 100 + Number.EPSILON) / 100;
     return {
       name: location.properties.name,
       lon,
       lat,
-      timezone: getTimezoneForCoords(lat, lon),
+      timezone: getTimezoneForCoords(rawLat, rawLon),
     };
   });
 }

--- a/src/utils/formatWeather.ts
+++ b/src/utils/formatWeather.ts
@@ -8,10 +8,18 @@ import * as RawWeather from "~/types/rawWeather";
 import { Theme } from "~/types/themes";
 
 import { getHourString } from "./getHourString";
+import {
+  getDayInTimezone,
+  getDayOfWeekInTimezone,
+  getHourInTimezone,
+  getMonthIndexInTimezone,
+  isSameDayInTimezone,
+} from "./timezone";
 
 export default function formatWeather(
   data: RawWeather.RawWeather,
 ): FormattedWeather.FormattedWeather {
+  const tz = data.timezone;
   const formattedData = {} as FormattedWeather.FormattedWeather;
   formattedData.city = data.city;
   formattedData.chartHours = [];
@@ -22,7 +30,7 @@ export default function formatWeather(
         if (formattedData.chartHours.length < 24) {
           const chartHour: FormattedWeather.ChartHour = {
             hour: hour.tempr,
-            hourText: getHourString(data.units.timeUnit, new Date(hour.date)),
+            hourText: getHourString(data.units.timeUnit, new Date(hour.date), tz),
             tempr: hour.tempr,
             feelslike: hour.feelslike,
             wind: hour.wind,
@@ -44,23 +52,23 @@ export default function formatWeather(
     formattedDay.chartHours = [];
     // Handle day of week
     let dayOfWeek = {} as string;
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (isSameDay(new Date(day.date), new Date())) {
+    const now = new Date();
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    if (isSameDayInTimezone(new Date(day.date), now, tz)) {
       dayOfWeek = i18n.t("day_today");
-    } else if (isSameDay(new Date(day.date), tomorrow)) {
+    } else if (isSameDayInTimezone(new Date(day.date), tomorrow, tz)) {
       dayOfWeek = i18n.t("day_tomorrow");
     } else {
-      dayOfWeek = Consts.Days[new Date(day.date).getDay()];
+      dayOfWeek = Consts.Days[getDayOfWeekInTimezone(new Date(day.date), tz)];
     }
     formattedDay.dayOfWeek = dayOfWeek;
-    formattedDay.sunrise = getHourString(data.units.timeUnit, new Date(day.sunrise));
-    formattedDay.sunset = getHourString(data.units.timeUnit, new Date(day.sunset));
-    formattedDay.icon = day.icon || getDayIcon(day);
+    formattedDay.sunrise = getHourString(data.units.timeUnit, new Date(day.sunrise), tz);
+    formattedDay.sunset = getHourString(data.units.timeUnit, new Date(day.sunset), tz);
+    formattedDay.icon = day.icon || getDayIcon(day, tz);
     formattedDay.text = day.text;
     formattedDay.tempHigh = getTemperatureString(data.units.temprUnit, day.tempHigh);
     formattedDay.tempLow = getTemperatureString(data.units.temprUnit, day.tempLow);
-    formattedDay.dateString = formatDate(day.date);
+    formattedDay.dateString = formatDate(day.date, tz);
 
     day.hours.forEach(hour => {
       formattedDay.hours.push(parseHour(hour, day.sunrise, day.sunset));
@@ -68,7 +76,7 @@ export default function formatWeather(
     day.hours.forEach(hour => {
       formattedDay.chartHours.push({
         hour: hour.tempr,
-        hourText: getHourString(data.units.timeUnit, new Date(hour.date)),
+        hourText: getHourString(data.units.timeUnit, new Date(hour.date), tz),
         tempr: hour.tempr,
         feelslike: hour.feelslike,
         wind: hour.wind,
@@ -87,7 +95,7 @@ export default function formatWeather(
 
   function parseHour(hour: RawWeather.Hour, sunrise: Date, sunset: Date): FormattedWeather.Hour {
     const formattedHour = {} as FormattedWeather.Hour;
-    formattedHour.hour = getHourString(data.units.timeUnit, new Date(hour.date));
+    formattedHour.hour = getHourString(data.units.timeUnit, new Date(hour.date), tz);
     formattedHour.text = hour.text;
     formattedHour.icon = hour.icon;
     formattedHour.theme = getTheme(hour.icon, sunrise, sunset);
@@ -119,10 +127,10 @@ export default function formatWeather(
   }
 }
 
-function getDayIcon(day: RawWeather.Day): WeatherIconEnum {
+function getDayIcon(day: RawWeather.Day, tz: string): WeatherIconEnum {
   // We only care about hours between these hours
   const hours = day.hours.filter(hour => {
-    return isBetween(new Date(hour.date).getHours(), 5, 23);
+    return isBetween(getHourInTimezone(new Date(hour.date), tz), 5, 23);
   });
   // No hours in the span, iterate all hours
   if (hours.length == 0) {
@@ -282,25 +290,13 @@ function getTemperatureString(unitTempr: string, tempr: number): string {
   }
 }
 function isMorning(sunrise: Date, sunset: Date) {
-  const lowHourSunrise = new Date(sunrise);
-  lowHourSunrise.setHours(lowHourSunrise.getHours() - 1);
-  const highHourSunrise = new Date(sunrise);
-  highHourSunrise.setHours(lowHourSunrise.getHours() + 1);
-
-  const lowHourSunset = new Date(sunset);
-  lowHourSunrise.setHours(lowHourSunset.getHours() - 1);
-  const highHourSunset = new Date(sunset);
-  highHourSunrise.setHours(lowHourSunset.getHours() + 1);
-
-  const currentDate = new Date();
-
-  if (
-    dateIsBetween(currentDate, lowHourSunrise, highHourSunrise) ||
-    dateIsBetween(currentDate, lowHourSunset, highHourSunset)
-  ) {
-    return true;
-  }
-  return false;
+  const oneHour = 60 * 60 * 1000;
+  const now = Date.now();
+  const sunriseMs = sunrise.getTime();
+  const sunsetMs = sunset.getTime();
+  const nearSunrise = now >= sunriseMs - oneHour && now <= sunriseMs + oneHour;
+  const nearSunset = now >= sunsetMs - oneHour && now <= sunsetMs + oneHour;
+  return nearSunrise || nearSunset;
 }
 function isBetween(x: number, lower: number, upper: number) {
   return lower <= x && x <= upper;
@@ -308,14 +304,7 @@ function isBetween(x: number, lower: number, upper: number) {
 function dateIsBetween(x: Date, lower: Date, upper: Date) {
   return x > lower && x < upper;
 }
-function isSameDay(d1: Date, d2: Date) {
-  return (
-    d1.getFullYear() === d2.getFullYear() &&
-    d1.getMonth() === d2.getMonth() &&
-    d1.getDate() === d2.getDate()
-  );
-}
-function formatDate(date: Date): string {
+function formatDate(date: Date, tz: string): string {
   const dateObj = new Date(date);
-  return dateObj.getDate() + " " + Consts.Months[dateObj.getMonth()];
+  return getDayInTimezone(dateObj, tz) + " " + Consts.Months[getMonthIndexInTimezone(dateObj, tz)];
 }

--- a/src/utils/getHourString.ts
+++ b/src/utils/getHourString.ts
@@ -1,23 +1,38 @@
 import { timeUnits } from "./constants";
 
-export function getHourString(unitTime: timeUnits, date: Date): string {
-  const minutes = (date.getMinutes() < 10 ? "0" : "") + date.getMinutes();
+function partsFor(date: Date, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormatPart[] {
+  return new Intl.DateTimeFormat("en-US", options).formatToParts(date);
+}
 
+function partValue(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes): string {
+  return parts.find(p => p.type === type)?.value ?? "";
+}
+
+export function getHourString(unitTime: timeUnits, date: Date, timeZone: string): string {
   switch (unitTime) {
-    case "twentyfour": {
-      const hours = (date.getHours() < 10 ? "0" : "") + date.getHours();
-      return hours + ":" + minutes;
-    }
     case "twelve": {
-      let hours = date.getHours();
-      const ampm = hours >= 12 ? " pm" : " am";
-      hours = hours % 12;
-      hours = hours ? hours : 12;
-      return hours + "." + minutes + ampm;
+      const parts = partsFor(date, {
+        timeZone,
+        hour: "numeric",
+        minute: "2-digit",
+        hourCycle: "h12",
+      });
+      const hours = partValue(parts, "hour");
+      const minutes = partValue(parts, "minute");
+      const dayPeriod = partValue(parts, "dayPeriod").toLowerCase();
+      return `${hours}.${minutes} ${dayPeriod}`;
     }
+    case "twentyfour":
     default: {
-      const hours = (date.getHours() < 10 ? "0" : "") + date.getHours();
-      return hours + ":" + minutes;
+      const parts = partsFor(date, {
+        timeZone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+      });
+      const hours = partValue(parts, "hour");
+      const minutes = partValue(parts, "minute");
+      return `${hours}:${minutes}`;
     }
   }
 }

--- a/src/utils/getHourString.ts
+++ b/src/utils/getHourString.ts
@@ -9,6 +9,8 @@ function partValue(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPa
 }
 
 export function getHourString(unitTime: timeUnits, date: Date, timeZone: string): string {
+  if (Number.isNaN(date.getTime())) return "N/A";
+
   switch (unitTime) {
     case "twelve": {
       const parts = partsFor(date, {

--- a/src/utils/parseWeather.ts
+++ b/src/utils/parseWeather.ts
@@ -9,9 +9,9 @@ import { parseWeatherYR } from "./yr";
 export function parseWeather(data: any, provider: Provider, location: Location) {
   switch (provider) {
     case "smhi":
-      return processWeather(parseWeatherSMHI(data, location.lon, location.lat, location.name));
+      return processWeather(parseWeatherSMHI(data, location));
     case "yr":
-      return processWeather(parseWeatherYR(data, location.lon, location.lat, location.name));
+      return processWeather(parseWeatherYR(data, location));
   }
 }
 

--- a/src/utils/smhi.ts
+++ b/src/utils/smhi.ts
@@ -67,7 +67,9 @@ function parseDays(
     // Iterate each hour
     for (const time2 of times) {
       if (isSameDayInTimezone(new Date(time2.time), iterationDate, tz)) {
-        iterationDay.hours.push(parseHour(time2, iterationDay.sunrise, iterationDay.sunset));
+        iterationDay.hours.push(
+          parseHour(time2, iterationDay.sunrise, iterationDay.sunset, lat, lon),
+        );
       }
     }
 
@@ -85,6 +87,8 @@ function parseHour(
   time: WeatherTypesSMHI.TimeSery,
   sunrise: Date,
   sunset: Date,
+  lat: number,
+  lon: number,
 ): WeatherTypesUni.Hour {
   const hour = {} as WeatherTypesUni.Hour;
   const data = time.data;
@@ -104,8 +108,14 @@ function parseHour(
   if (data.symbol_code !== undefined) {
     const correctedForIndex = data.symbol_code - 1;
     hour.text = WeatherTypesSMHI.TextList[correctedForIndex];
-    const t = new Date(hour.date).getTime();
-    const isDay = t >= sunrise.getTime() && t <= sunset.getTime();
+    const date = new Date(hour.date);
+    const t = date.getTime();
+    const sunriseMs = sunrise.getTime();
+    const sunsetMs = sunset.getTime();
+    const isDay =
+      !Number.isNaN(sunriseMs) && !Number.isNaN(sunsetMs)
+        ? t >= sunriseMs && t <= sunsetMs
+        : SunCalc.getPosition(date, lat, lon).altitude > 0;
     if (isDay) {
       hour.icon = WeatherTypesSMHI.IconListDay[correctedForIndex];
     } else {

--- a/src/utils/smhi.ts
+++ b/src/utils/smhi.ts
@@ -1,5 +1,6 @@
 import SunCalc from "suncalc";
 
+import Location from "~/types/location";
 import * as WeatherTypesUni from "~/types/rawWeather";
 import * as WeatherTypesSMHI from "~/types/smhi";
 import {
@@ -11,16 +12,16 @@ import {
   windUnits,
 } from "~/utils/constants";
 
-import { calcFeelsLike, isSameDay } from "./weatherTransforms";
+import { isSameDayInTimezone } from "./timezone";
+import { calcFeelsLike } from "./weatherTransforms";
 
 export function parseWeatherSMHI(
   weatherData: WeatherTypesSMHI.WeatherData,
-  lon: number,
-  lat: number,
-  city: string,
+  location: Location,
 ): WeatherTypesUni.RawWeather {
   const weatherDataUni = {} as WeatherTypesUni.RawWeather;
-  weatherDataUni.city = city;
+  weatherDataUni.city = location.name;
+  weatherDataUni.timezone = location.timezone;
   weatherDataUni.days = [];
   weatherDataUni.units = {
     temprUnit: temprUnits.c,
@@ -31,7 +32,12 @@ export function parseWeatherSMHI(
     timeUnit: timeUnits.twentyfour,
   };
 
-  weatherDataUni.days = parseDays(weatherData.timeSeries, lon, lat);
+  weatherDataUni.days = parseDays(
+    weatherData.timeSeries,
+    location.lon,
+    location.lat,
+    location.timezone,
+  );
 
   return weatherDataUni;
 }
@@ -39,17 +45,18 @@ function parseDays(
   times: WeatherTypesSMHI.TimeSery[],
   lon: number,
   lat: number,
+  tz: string,
 ): WeatherTypesUni.Day[] {
   const days = [];
   let iterationDate = new Date(0);
 
   // Iterate each day
   for (const time1 of times) {
-    if (isSameDay(new Date(time1.time), new Date(iterationDate))) continue;
+    if (isSameDayInTimezone(new Date(time1.time), iterationDate, tz)) continue;
 
     const iterationDay = {} as WeatherTypesUni.Day;
     iterationDay.hours = [];
-    iterationDate = time1.time;
+    iterationDate = new Date(time1.time);
 
     // Set sunrise and sunset
     iterationDay.date = time1.time;
@@ -59,7 +66,7 @@ function parseDays(
 
     // Iterate each hour
     for (const time2 of times) {
-      if (isSameDay(new Date(time2.time), new Date(iterationDate))) {
+      if (isSameDayInTimezone(new Date(time2.time), iterationDate, tz)) {
         iterationDay.hours.push(parseHour(time2, iterationDay.sunrise, iterationDay.sunset));
       }
     }
@@ -97,10 +104,9 @@ function parseHour(
   if (data.symbol_code !== undefined) {
     const correctedForIndex = data.symbol_code - 1;
     hour.text = WeatherTypesSMHI.TextList[correctedForIndex];
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
+    const t = new Date(hour.date).getTime();
+    const isDay = t >= sunrise.getTime() && t <= sunset.getTime();
+    if (isDay) {
       hour.icon = WeatherTypesSMHI.IconListDay[correctedForIndex];
     } else {
       hour.icon = WeatherTypesSMHI.IconListNight[correctedForIndex];

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,71 @@
+import tzLookup from "tz-lookup";
+
+const browserTimezone = (): string => Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export function getTimezoneForCoords(lat: number, lon: number): string {
+  try {
+    return tzLookup(lat, lon);
+  } catch {
+    return browserTimezone();
+  }
+}
+
+export function validateTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function partsFor(date: Date, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormatPart[] {
+  return new Intl.DateTimeFormat("en-US", options).formatToParts(date);
+}
+
+function partValue(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes): string {
+  return parts.find(p => p.type === type)?.value ?? "";
+}
+
+export function getHourInTimezone(date: Date, timeZone: string): number {
+  const parts = partsFor(date, { timeZone, hour: "2-digit", hourCycle: "h23" });
+  return parseInt(partValue(parts, "hour"), 10);
+}
+
+export function getYMDInTimezone(date: Date, timeZone: string): string {
+  const parts = partsFor(date, {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return `${partValue(parts, "year")}-${partValue(parts, "month")}-${partValue(parts, "day")}`;
+}
+
+export function getDayOfWeekInTimezone(date: Date, timeZone: string): number {
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  const parts = partsFor(date, { timeZone, weekday: "short" });
+  return weekdayMap[partValue(parts, "weekday")] ?? 0;
+}
+
+export function getDayInTimezone(date: Date, timeZone: string): number {
+  const parts = partsFor(date, { timeZone, day: "numeric" });
+  return parseInt(partValue(parts, "day"), 10);
+}
+
+export function getMonthIndexInTimezone(date: Date, timeZone: string): number {
+  const parts = partsFor(date, { timeZone, month: "numeric" });
+  return parseInt(partValue(parts, "month"), 10) - 1;
+}
+
+export function isSameDayInTimezone(d1: Date, d2: Date, timeZone: string): boolean {
+  return getYMDInTimezone(d1, timeZone) === getYMDInTimezone(d2, timeZone);
+}

--- a/src/utils/weatherTransforms.ts
+++ b/src/utils/weatherTransforms.ts
@@ -23,10 +23,3 @@ export function calcFeelsLike(tempr: number, humidity: number, wind: number): nu
     return tempr;
   }
 }
-export function isSameDay(d1: Date, d2: Date) {
-  return (
-    d1.getFullYear() === d2.getFullYear() &&
-    d1.getMonth() === d2.getMonth() &&
-    d1.getDate() === d2.getDate()
-  );
-}

--- a/src/utils/yr.ts
+++ b/src/utils/yr.ts
@@ -11,19 +11,20 @@ import {
 } from "utils/constants";
 
 import { WeatherIconEnum } from "~/enums/WeatherIcon";
+import Location from "~/types/location";
 import * as WeatherTypesUni from "~/types/rawWeather";
 import * as WeatherTypesYR from "~/types/yr";
 
-import { calcFeelsLike, isSameDay } from "./weatherTransforms";
+import { getHourInTimezone, isSameDayInTimezone } from "./timezone";
+import { calcFeelsLike } from "./weatherTransforms";
 
 export function parseWeatherYR(
   weatherData: WeatherTypesYR.WeatherData,
-  lon: number,
-  lat: number,
-  city: string,
+  location: Location,
 ): WeatherTypesUni.RawWeather {
   const weatherDataUni = {} as WeatherTypesUni.RawWeather;
-  weatherDataUni.city = city;
+  weatherDataUni.city = location.name;
+  weatherDataUni.timezone = location.timezone;
   weatherDataUni.days = [];
   weatherDataUni.units = {
     temprUnit: temprUnits.c,
@@ -34,7 +35,12 @@ export function parseWeatherYR(
     timeUnit: timeUnits.twentyfour,
   };
 
-  weatherDataUni.days = parseDays(weatherData.properties.timeseries, lon, lat);
+  weatherDataUni.days = parseDays(
+    weatherData.properties.timeseries,
+    location.lon,
+    location.lat,
+    location.timezone,
+  );
 
   return weatherDataUni;
 }
@@ -43,17 +49,18 @@ function parseDays(
   times: WeatherTypesYR.Timesery[],
   lon: number,
   lat: number,
+  tz: string,
 ): WeatherTypesUni.Day[] {
   const days = [];
   let iterationDate = new Date(0);
 
   // Iterate each day
   for (let i = 0; i < times.length; i++) {
-    if (isSameDay(new Date(times[i].time), new Date(iterationDate))) continue;
+    if (isSameDayInTimezone(new Date(times[i].time), iterationDate, tz)) continue;
 
     const iterationDay = {} as WeatherTypesUni.Day;
     iterationDay.hours = [];
-    iterationDate = times[i].time;
+    iterationDate = new Date(times[i].time);
 
     // Set sunrise sunset
     iterationDay.date = times[i].time;
@@ -63,7 +70,11 @@ function parseDays(
 
     iterationDay.icon = getDayIcon(times[i]);
 
-    const twelveHour = times.find(hour => new Date(hour.time).getHours() == 12);
+    const twelveHour = times.find(
+      hour =>
+        isSameDayInTimezone(new Date(hour.time), iterationDate, tz) &&
+        getHourInTimezone(new Date(hour.time), tz) === 12,
+    );
     if (twelveHour) {
       const dayNightIcons = [getDayIcon(twelveHour), iterationDay.icon];
       iterationDay.icon = Math.max(...dayNightIcons);
@@ -71,7 +82,7 @@ function parseDays(
 
     // Iterate each hour
     for (const time2 of times) {
-      if (isSameDay(new Date(time2.time), new Date(iterationDate))) {
+      if (isSameDayInTimezone(new Date(time2.time), iterationDate, tz)) {
         iterationDay.hours.push(parseHour(time2, iterationDay.sunrise, iterationDay.sunset));
       }
     }
@@ -89,6 +100,12 @@ function parseDays(
   }
   return days;
 }
+
+function isDaylight(hour: Date | string, sunrise: Date, sunset: Date): boolean {
+  const t = new Date(hour).getTime();
+  return t >= sunrise.getTime() && t <= sunset.getTime();
+}
+
 function parseHour(
   time: WeatherTypesYR.Timesery,
   sunrise: Date,
@@ -112,31 +129,18 @@ function parseHour(
   hour.cloud = time.data.instant.details.cloud_area_fraction;
   hour.feelslike = calcFeelsLike(hour.tempr, hour.humidity, hour.wind);
   const symbol = time.data.next_1_hours?.summary.symbol_code;
+  const isDay = isDaylight(hour.date, sunrise, sunset);
   if (symbol == null) {
     hour.icon = WeatherIconEnum.NOT_AVAILABLE;
     hour.text = "N/A";
   } else if (symbol.startsWith("clearsky")) {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.CLEAR_DAY;
-    } else {
-      hour.icon = WeatherIconEnum.CLEAR_NIGHT;
-    }
+    hour.icon = isDay ? WeatherIconEnum.CLEAR_DAY : WeatherIconEnum.CLEAR_NIGHT;
     hour.text = i18n.t("w_clear");
   } else if (symbol === "cloudy") {
     hour.icon = WeatherIconEnum.CLOUDY;
     hour.text = i18n.t("w_cloudy");
   } else if (symbol.startsWith("fair")) {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_DAY;
-    } else {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_NIGHT;
-    }
+    hour.icon = isDay ? WeatherIconEnum.PARTLY_CLOUDY_DAY : WeatherIconEnum.PARTLY_CLOUDY_NIGHT;
     hour.text = i18n.t("w_varying_cloudiness");
   } else if (symbol === "fog") {
     hour.icon = WeatherIconEnum.FOG;
@@ -148,14 +152,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "heavyrainshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.EXTREME_DAY_RAIN;
-    } else {
-      hour.icon = WeatherIconEnum.EXTREME_NIGHT_RAIN;
-    }
+    hour.icon = isDay ? WeatherIconEnum.EXTREME_DAY_RAIN : WeatherIconEnum.EXTREME_NIGHT_RAIN;
     hour.text = i18n.t("w_heavy_rain_showers");
   } else if (symbol.startsWith("heavyrainshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -167,14 +164,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "heavysleetshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.EXTREME_SLEET;
-    } else {
-      hour.icon = WeatherIconEnum.EXTREME_SLEET;
-    }
+    hour.icon = WeatherIconEnum.EXTREME_SLEET;
     hour.text = i18n.t("w_heavy_sleet_showers");
   } else if (symbol.startsWith("heavysleetshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -186,14 +176,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.EXTREME_SNOW;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "heavysnowshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.EXTREME_SNOW;
-    } else {
-      hour.icon = WeatherIconEnum.EXTREME_SNOW;
-    }
+    hour.icon = WeatherIconEnum.EXTREME_SNOW;
     hour.text = i18n.t("w_heavy_snow_showers");
   } else if (symbol.startsWith("heavysnowshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -205,14 +188,9 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "lightrainshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_DAY_RAIN;
-    } else {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_NIGHT_RAIN;
-    }
+    hour.icon = isDay
+      ? WeatherIconEnum.PARTLY_CLOUDY_DAY_RAIN
+      : WeatherIconEnum.PARTLY_CLOUDY_NIGHT_RAIN;
     hour.text = i18n.t("w_light_rain_showers");
   } else if (symbol.startsWith("lightrainshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -224,14 +202,9 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "lightsleetshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_DAY_SLEET;
-    } else {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_NIGHT_SLEET;
-    }
+    hour.icon = isDay
+      ? WeatherIconEnum.PARTLY_CLOUDY_DAY_SLEET
+      : WeatherIconEnum.PARTLY_CLOUDY_NIGHT_SLEET;
     hour.text = i18n.t("w_light_sleet_showers");
   } else if (symbol.startsWith("lightssleetshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -243,27 +216,15 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "lightsnowshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_DAY_SNOW;
-    } else {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_NIGHT_SNOW;
-    }
+    hour.icon = isDay
+      ? WeatherIconEnum.PARTLY_CLOUDY_DAY_SNOW
+      : WeatherIconEnum.PARTLY_CLOUDY_NIGHT_SNOW;
     hour.text = i18n.t("w_light_snow_showers");
   } else if (symbol.startsWith("lightssnowshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.startsWith("partlycloudy")) {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_DAY;
-    } else {
-      hour.icon = WeatherIconEnum.PARTLY_CLOUDY_NIGHT;
-    }
+    hour.icon = isDay ? WeatherIconEnum.PARTLY_CLOUDY_DAY : WeatherIconEnum.PARTLY_CLOUDY_NIGHT;
     hour.text = i18n.t("w_varying_cloudiness");
   } else if (symbol === "rain") {
     hour.icon = WeatherIconEnum.RAIN;
@@ -272,14 +233,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "rainshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.OVERCAST_DAY_RAIN;
-    } else {
-      hour.icon = WeatherIconEnum.OVERCAST_NIGHT_RAIN;
-    }
+    hour.icon = isDay ? WeatherIconEnum.OVERCAST_DAY_RAIN : WeatherIconEnum.OVERCAST_NIGHT_RAIN;
     hour.text = i18n.t("w_moderate_rain");
   } else if (symbol.startsWith("rainshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -291,14 +245,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "sleetshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.OVERCAST_DAY_SLEET;
-    } else {
-      hour.icon = WeatherIconEnum.OVERCAST_NIGHT_SLEET;
-    }
+    hour.icon = isDay ? WeatherIconEnum.OVERCAST_DAY_SLEET : WeatherIconEnum.OVERCAST_NIGHT_SLEET;
     hour.text = i18n.t("w_moderate_sleet_showers");
   } else if (symbol.startsWith("sleetshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;
@@ -310,14 +257,7 @@ function parseHour(
     hour.icon = WeatherIconEnum.THUNDER;
     hour.text = i18n.t("w_thunder");
   } else if (symbol.split("_")[0] === "snowshowers") {
-    if (
-      new Date(hour.date).getHours() >= new Date(sunrise).getHours() &&
-      new Date(hour.date).getHours() <= new Date(sunset).getHours()
-    ) {
-      hour.icon = WeatherIconEnum.OVERCAST_DAY_SNOW;
-    } else {
-      hour.icon = WeatherIconEnum.OVERCAST_NIGHT_SNOW;
-    }
+    hour.icon = isDay ? WeatherIconEnum.OVERCAST_DAY_SNOW : WeatherIconEnum.OVERCAST_NIGHT_SNOW;
     hour.text = i18n.t("w_moderate_snow_showers");
   } else if (symbol.startsWith("snowshowersandthunder")) {
     hour.icon = WeatherIconEnum.THUNDER;

--- a/src/utils/yr.ts
+++ b/src/utils/yr.ts
@@ -83,7 +83,9 @@ function parseDays(
     // Iterate each hour
     for (const time2 of times) {
       if (isSameDayInTimezone(new Date(time2.time), iterationDate, tz)) {
-        iterationDay.hours.push(parseHour(time2, iterationDay.sunrise, iterationDay.sunset));
+        iterationDay.hours.push(
+          parseHour(time2, iterationDay.sunrise, iterationDay.sunset, lat, lon),
+        );
       }
     }
 
@@ -101,15 +103,29 @@ function parseDays(
   return days;
 }
 
-function isDaylight(hour: Date | string, sunrise: Date, sunset: Date): boolean {
-  const t = new Date(hour).getTime();
-  return t >= sunrise.getTime() && t <= sunset.getTime();
+function isDaylight(
+  hour: Date | string,
+  sunrise: Date,
+  sunset: Date,
+  lat: number,
+  lon: number,
+): boolean {
+  const date = new Date(hour);
+  const t = date.getTime();
+  const sunriseMs = sunrise.getTime();
+  const sunsetMs = sunset.getTime();
+  if (!Number.isNaN(sunriseMs) && !Number.isNaN(sunsetMs)) {
+    return t >= sunriseMs && t <= sunsetMs;
+  }
+  return SunCalc.getPosition(date, lat, lon).altitude > 0;
 }
 
 function parseHour(
   time: WeatherTypesYR.Timesery,
   sunrise: Date,
   sunset: Date,
+  lat: number,
+  lon: number,
 ): WeatherTypesUni.Hour {
   const hour = {} as WeatherTypesUni.Hour;
   hour.date = time.time;
@@ -129,7 +145,7 @@ function parseHour(
   hour.cloud = time.data.instant.details.cloud_area_fraction;
   hour.feelslike = calcFeelsLike(hour.tempr, hour.humidity, hour.wind);
   const symbol = time.data.next_1_hours?.summary.symbol_code;
-  const isDay = isDaylight(hour.date, sunrise, sunset);
+  const isDay = isDaylight(hour.date, sunrise, sunset, lat, lon);
   if (symbol == null) {
     hour.icon = WeatherIconEnum.NOT_AVAILABLE;
     hour.text = "N/A";


### PR DESCRIPTION
## Summary
- Add `tz-lookup` and a `src/utils/timezone.ts` helper that resolves a timezone from coordinates and exposes Intl-based helpers for hour, day, weekday, month, and same-day checks in a target timezone.
- Thread `timezone` through `Location`, `RawWeather`, the SMHI/YR parsers, `formatWeather`, `getHourString`, and the radar map so hour labels, day grouping, sunrise/sunset, and date strings reflect the forecast location instead of the viewer's browser.
- Persist `timezone` on saved/selected locations and transparently upgrade legacy entries on load.

## Test plan
- [ ] Search for a location in a different timezone (e.g. Tokyo) and confirm hour labels, "Today/Tomorrow" grouping, sunrise/sunset, and the chart's hour axis match the location's local time, not the browser's.
- [ ] Reload with an existing saved location stored before this change and confirm it gets a timezone backfilled without losing selection.
- [ ] Toggle the time format to 12h and verify AM/PM rendering still works for a remote timezone.
- [ ] Confirm the radar map timestamp uses the location's timezone.